### PR TITLE
look for shortened club names in stories and add tests for this

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,7 +24,7 @@
       "type": "node",
       "request": "launch",
       "name": "Skill Test",
-      "program": "${workspaceRoot}/test/skillTest/main.js"
+      "program": "${workspaceRoot}/test/skillTest/test.js"
     },
     {
       "type": "node",

--- a/clubNames/clubNames.json
+++ b/clubNames/clubNames.json
@@ -1,0 +1,624 @@
+{
+  "clubs": [
+    {
+      "utterance": "accrington stanley",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "alfreton",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "altrincham",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "arsenal",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "aston villa",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "barnet",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "barnsley",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "barrow",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "birmingham",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "blackburn",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "blackpool",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "bolton",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "boreham wood",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "bournemouth",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "brackley",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "bradford",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "braintree",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "brentford",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "brighton",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "bristol city",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "bristol rovers",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "burnley",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "burton",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "bury",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "cambridge",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "cardiff",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "carlisle",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "charlton",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "chelsea",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "cheltenham",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "chesham",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "chesterfield",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "colchester",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "coventry",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "crawley",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "crewe",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "crystal palace",
+      "hasNickname": true,
+      "nicknames": ["crystal palace", "palace"]
+    },
+    {
+      "utterance": "curzon ashton",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "dagenham and redbridge",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "dartford",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "derby",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "doncaster",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "dover",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "eastbourne",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "eastleigh",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "everton",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "exeter",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "fleetwood",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "fulham",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "gillingham",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "grimsby",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "halifax",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "harrow",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "hartlepool",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "huddersfield",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "hull",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "ipswich",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "kidderminster",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "leeds",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "leicester",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "leyton orient",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "lincoln",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "liverpool",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "luton",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "macclesfield",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "maidstone",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "manchester city",
+      "hasNickname": true,
+      "nicknames": ["man city", "manchester city"]
+    },
+    {
+      "utterance": "manchester united",
+      "hasNickname": true,
+      "nicknames": ["man united", "man utd", "manchester utd", "manchester united"]
+    },
+    {
+      "utterance": "mansfield",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "merstham",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "middlesbrough",
+      "hasNickname": true,
+      "nicknames": ["boro", "middlesbrough"]
+    },
+    {
+      "utterance": "millwall",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "mk dons",
+      "hasNickname": true,
+      "nicknames": ["milton keynes dons", "mk dons"]
+    },
+    {
+      "utterance": "morecambe",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "newcastle",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "newport",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "northampton",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "norwich",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "nottingham forest",
+      "hasNickname": true,
+      "nicknames": ["forest", "nottingham forest"]
+    },
+    {
+      "utterance": "notts county",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "oldham",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "oxford",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "peterborough",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "plymouth",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "port vale",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "portsmouth",
+      "hasNickname": true,
+      "nicknames": ["pompey", "portsmouth"]
+    },
+    {
+      "utterance": "preston",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "queens park rangers",
+      "hasNickname": true,
+      "nicknames": ["qpr", "queens park rangers"]
+    },
+    {
+      "utterance": "reading",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "rochdale",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "rotherham",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "scunthorpe",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "sheffield united",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "sheffield wednesday",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "shrewsbury",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "solihull moors",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "southampton",
+      "hasNickname": true,
+      "nicknames": ["saints", "southampton"]
+    },
+    {
+      "utterance": "southend",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "southport",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "spennymoor",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "st albans",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "stamford",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "stevenage",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "stockport",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "stoke",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "stourbridge",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "sunderland",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "sutton",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "swansea",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "swindon",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "taunton",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "tottenham",
+      "hasNickname": true,
+      "nicknames": ["spurs", "tottenham"]
+    },
+    {
+      "utterance": "walsall",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "watford",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "west brom",
+      "hasNickname": true,
+      "nicknames": ["west bromwich albion", "west brom"]
+    },
+    {
+      "utterance": "west ham",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "westfields",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "whitehawk",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "wigan",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "wimbledon",
+      "hasNickname": true,
+      "nicknames": ["afc wimbledon", "wimbledon"]
+    },
+    {
+      "utterance": "woking",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "wolves",
+      "hasNickname": true,
+      "nicknames": ["wolverhampton wanderers", "wolves"]
+    },
+    {
+      "utterance": "wycombe",
+      "hasNickname": false,
+      "nicknames": []
+    },
+    {
+      "utterance": "yeovil",
+      "hasNickname": false,
+      "nicknames": []
+    }
+  ]
+}

--- a/clubNames/utterances.txt
+++ b/clubNames/utterances.txt
@@ -1,0 +1,125 @@
+Accrington Stanley
+Alfreton
+Altrincham
+Arsenal
+Aston Villa
+Barnet
+Barnsley
+Barrow
+Birmingham
+Blackburn
+Blackpool
+Bolton
+Bolton Wanderers
+Boreham Wood
+Bournemouth
+Brackley
+Bradford
+Braintree
+Brentford
+Brighton
+Bristol
+Bristol Rovers
+Burnley
+Burton
+Bury
+Cambridge
+Cardiff
+Carlisle
+Charlton
+Chelsea
+Cheltenham
+Chesham
+Chesterfield
+Colchester
+Coventry
+Crawley
+Crewe
+Crystal Palace
+Curzon Ashton
+Dagenham and Redbridge
+Dartford
+Derby
+Doncaster
+Dover
+Eastbourne
+Eastleigh
+Everton
+Exeter
+Fleetwood
+Fulham
+Gillingham
+Grimsby
+Halifax
+Harrow
+Hartlepool
+Huddersfield
+Hull
+Ipswich
+Kidderminster
+Leeds
+Leicester
+Leyton Orient
+Lincoln
+Liverpool
+Luton
+Macclesfield
+Maidstone
+Manchester
+Manchester United
+Mansfield
+Merstham
+Middlesbrough
+Millwall
+MK Dons
+Morecambe
+Newcastle
+Newport
+Northampton
+Norwich
+Nottingham Forest
+Notts County
+Oldham
+Oxford
+Peterborough
+Plymouth
+Port Vale
+Portsmouth
+Preston
+Queens Park Rangers
+Reading
+Rochdale
+Rotherham
+Scunthorpe
+Sheffield
+Sheffield Wednesday
+Shrewsbury
+Solihull Moors
+Southampton
+Southend
+Southport
+Spennymoor
+St Albans
+Stamford
+Stevenage
+Stockport
+Stoke
+Stourbridge
+Sunderland
+Sutton
+Swansea
+Swindon
+Taunton
+Tottenham
+Walsall
+Watford
+West Brom
+West Ham
+Westfields
+Whitehawk
+Wigan
+Wimbledon
+Woking
+Wolves
+Wycombe
+Yeovil

--- a/src/createNameData.js
+++ b/src/createNameData.js
@@ -1,0 +1,52 @@
+/*
+CREATING CLUB NAME DATA
+This module is not actually deployed as production code, and is only
+used to create or update the initial club name data used by alexa.
+*/
+
+var rp = require('request-promise');
+var fs = require('fs');
+
+var prem = "http://api.football-data.org/v1/soccerseasons/426/teams"
+var champ = "http://api.football-data.org/v1/soccerseasons/427/teams"
+var league1 = "http://api.football-data.org/v1/soccerseasons/428/teams"
+var league2 = "http://api.football-data.org/v1/soccerseasons/429/teams"
+
+// get data from the api to eventually create the utterances.
+// getData(prem, '../clubNames/prem.txt')
+// getData(champ, '../clubNames/champ.txt')
+// getData(league1, '../clubNames/league1.txt')
+// getData(league2, '../clubNames/league2.txt')
+
+function getData(url, filePath) {
+  rp({uri: url, json: true}).then(function(json){
+    var teams = json.teams.map(function(obj){
+      return {longName: obj.name, shortName: obj.shortName}
+    })
+    var fileStream = fs.createWriteStream(filePath);
+    fileStream.write(teams.join(`\n`), x => {
+      console.log(`wrote ${filePath}`)
+    })
+  });
+}
+
+// use the utterances.txt document to create an array of objects
+// createNamesObject('../clubNames/utterances.txt', '../clubNames/clubNames.json')
+
+
+function createNamesObject(utterancesFile, outputPath) {
+  var utterances = fs.readFileSync(utterancesFile, 'utf8')
+  var data = utterances.toString()
+    .split(`\n`)
+    .map(el => { return el.toLowerCase() })
+    .map(str => {
+      return { utterance: str, hasNickname: false, nickNames: [] }
+    })
+  var json = JSON.stringify({clubs: data})
+  var fileStream = fs.createWriteStream(outputPath);
+  fileStream.write(json, z => {
+    console.log(`wrote to ${outputPath}`)
+  })
+}
+
+

--- a/src/nameSearch.js
+++ b/src/nameSearch.js
@@ -2,15 +2,45 @@
   NAME CHECKER
   Responsible for finding names of football clubs from arrays of story strings.
 */
+var fs = require('fs');
 
-function findNameInString(name, storyString) {
-  return storyString.toLowerCase().includes(name.toLowerCase())
+var clubNames = fs.readFileSync('clubNames/clubNames.json');
+clubNames = JSON.parse(clubNames);
+
+function findClubNameInString(club, storyString) {
+  var story = storyString.toLowerCase();
+
+  if(club.hasNickname){
+    return club.nicknames.some(str => {
+      return story.includes(str)
+    })
+  }
+  else {
+    return story.includes(club.utterance)
+  }
 }
 
-function findNameFromStories(name, storyArray) {
-  return storyArray.filter(function(el) {
-    return findNameInString(name, el)
-  })
+function findNameObject(name, objArray) {
+  return objArray.find(obj => {
+    return name === obj.utterance
+  }) 
+}
+
+function findNameFromStories(utterance, storyArray) {
+  var name = utterance.toLowerCase()
+  var nameObject = findNameObject(name, clubNames.clubs)
+
+  // if there were no club Objects matching the name, then nameObject will be `undefined`
+  if (typeof nameObject === 'undefined') {
+    return []
+  }
+  else{
+    var matches = storyArray.filter(function(el) {
+      return findClubNameInString(nameObject, el)
+    })
+  // This is a new bit of syntax that dedupes an array. 
+    return Array.from( new Set(matches) )
+  }
 }
 
 module.exports = {

--- a/test/nameSearchTest.js
+++ b/test/nameSearchTest.js
@@ -5,9 +5,9 @@ var expect = require('chai').expect;
 var NameSearch = require('../src/nameSearch.js');
 var testStories = [
   "Brighton and Hove Albion won the league on Friday",
-  "Newcastle Slipped up against Preston",
-  "Rotherham were relegated",
-  "Manchester United forward Wayne Rooney has left the club",
+  "Sheffield Wednesday's team slipped up against Preston",
+  "Spurs missed out on the title",
+  "Man United forward Wayne Rooney has left the club",
   "Brighton rejected a £30m offer from Manchester United for young midfielder Solly March",
   "Brighton midfielder Dale Stephens signed a new contract"
 ]
@@ -16,13 +16,13 @@ describe('NameSearch', function () {
   describe('FindNameInStories', function () {   
     it('should return an array of any strings containing the given name', function () {
       NameSearch.findNameFromStories("Brighton", testStories).should.have.lengthOf(3)
-      NameSearch.findNameFromStories("Rovrum", testStories).should.have.lengthOf(0)
     });
     it('handles club names with more than one word', function () {
-      NameSearch.findNameFromStories("Manchester United", testStories).should.have.lengthOf(2)
+      NameSearch.findNameFromStories("Sheffield Wednesday", testStories).should.have.lengthOf(1)
     });      
-    xit('handles short versions of some club names', function () {
-      
+    it('handles short versions of some club names', function () {
+      NameSearch.findNameFromStories("Manchester United", testStories).should.have.lengthOf(2)
+      NameSearch.findNameFromStories("Tottenham", testStories).should.have.lengthOf(1)
     });    
   });
 });

--- a/test/skillTest/main.js
+++ b/test/skillTest/main.js
@@ -1,6 +1,0 @@
-var SkillTest = require('./skillTest.js');
-
-// Edit this callback to test different skills
-
-SkillTest.testFile('./getRumoursRequest.json');
-// SkillTest.testFile('./helpRequest.json')

--- a/test/skillTest/test.js
+++ b/test/skillTest/test.js
@@ -1,0 +1,7 @@
+var SkillTest = require('./skillTest.js');
+
+// Edit this callback to test different skills
+
+// SkillTest.testFile('./getRumoursRequest.json');
+// SkillTest.testFile('./helpRequest.json');
+SkillTest.testFile('./launchRequest.json');


### PR DESCRIPTION
this pr adds a mechanism to check for shortened club names, like `man united` or `spurs` in stories, and match them to their longer names.