### PR TITLE
add dynamoDB table for cache and only refresh once per day

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# The Skill Test file, which changes depending on which skill you're testing
+test/skillTest/test.js

--- a/src/db.js
+++ b/src/db.js
@@ -1,0 +1,54 @@
+var AWS = require('aws-sdk');
+AWS.config.region = 'eu-west-1';
+
+const Dynamo = new AWS.DynamoDB.DocumentClient();
+
+function writeToDB(item, table){
+  return new Promise((resolve, reject) => {
+    if (table === undefined || table === null) {
+      reject(`The table argument is ${table}.`);
+    }
+    else {
+      Dynamo.put({
+        TableName: table,
+        Item: item
+      }, (err, result) => {
+        if (err) {
+          reject(err);
+        }
+        else {
+          console.log("created record");
+          resolve(result);
+        }
+      })
+    }
+  });
+}
+
+function readFromDB(item, table){
+  return new Promise((resolve, reject) => {
+    if (table == undefined || table === null) {
+      reject(`The table argument is ${table}`);
+    }
+    else {
+      Dynamo.get({
+        TableName: table,
+        Key: item
+      }, (err, data) => {
+        if (err) {
+          reject(err);
+        }
+        else {
+          resolve(data);
+        }
+      })
+    }
+  })
+}
+
+module.exports = {
+  read: readFromDB,
+  write: writeToDB
+}
+
+

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -1,0 +1,82 @@
+/*
+DISPATCHER
+Handles requests, checks whether the cache is up to date and 
+sends back new or cached data to the client
+*/
+
+const DB = require('./db.js');
+const Scraper = require('./scraper.js');
+const NameSearch = require('./nameSearch.js');
+
+/*
+Return the cache if the stories are from today, 
+or scrape some more from the URL, update the cache and 
+return the new stories.
+
+`paperType` should be "national". TODO: support "regional" here
+*/
+function dispatch(paperType) {
+  var tableName = 'footballRumours';
+  var url = "http://www.skysports.com/football/transfer-paper-talk"
+  return new Promise((resolve, reject) => {
+    fetchFromCache(paperType, tableName).then(dbReply => {
+      // if we found an item, check if it is from today
+      if (isFromToday(dbReply)) {
+        resolve(dbReply.stories)
+      }
+      else {
+      // It wasn't from today, so fetch a new set of stories, add to the DB and return
+        fetchNewStories(url, tableName).then(stories => {
+          resolve(stories)
+        })
+      }
+    })
+    .catch(err => {
+      // we didn't find an item in the DB, so try to insert a new one and return stories.
+      fetchNewStories(url, tableName).then(stories => {
+        resolve(stories)
+      }).catch(error => { reject(err) })
+    })   
+  });
+}
+
+// fetch the cache from the DB
+
+function fetchFromCache(type, dbTableName){
+  return new Promise((resolve, reject) => {
+    DB.read({type: type}, dbTableName).then(res =>{
+      // check that it found a match, return the Item itself or reject the promise.
+      res.hasOwnProperty('Item') ? resolve(res["Item"]) : reject(res)
+    })
+    .catch(err => {
+      reject(err)
+    })
+  });  
+}
+
+// check whether the cache contains a record from the same day
+function isFromToday(storiesObject) {
+  var today = new Date().getDay()
+  var cacheDay = new Date(storiesObject.date).getDay();
+  return cacheDay === today
+}
+
+// scrape the url, add to the cache and then return the stories
+function fetchNewStories(url, dbTableName) {
+  return new Promise((resolve, reject) => {
+    Scraper.scrape(url, '.paper-stories').then(obj => {
+      var data = {
+        date: new Date().toString(),
+        type: "national",
+        stories: obj.stories
+      }
+      DB.write(data, dbTableName)
+      resolve(obj.stories)
+    })   
+  });
+}
+
+module.exports = {
+  dispatch: dispatch
+}
+

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 var Alexa = require('alexa-sdk');
 var NameSearch = require('./nameSearch.js');
-var Scraper = require('./scraper.js');
+var Dispatcher = require('./dispatcher.js');
 
 var url = "http://www.skysports.com/football/transfer-paper-talk"
 
@@ -30,16 +30,17 @@ var handlers = {
     }
     // use the function to match any stories.
     var stories = [];
-    
-    Scraper.scrape(url, '.paper-stories').then(obj => {
-      stories = NameSearch.findNameFromStories(clubName, obj.stories)
+    // Dispatcher will handle the logic of fetching from the DB or updating it for us...
+    Dispatcher.dispatch("national").then(res => {
+      // Find our club from the array of stories returned by the Dispatcher.
+      stories = NameSearch.findNameFromStories(clubName, res)
+      // if there are some matches, add this to the output and tell the user
       if (stories.length > 0) {
         var speechOutput = this.t('FOUND_STORIES_MESSAGE', clubName)
-        var stories = stories.join(". ")
         this.attributes['speechOutput'] = speechOutput += stories
         this.emit(':tell', this.attributes['speechOutput'])
       }
-      // if there were no stories, tell the user...
+      // if there were no stories that matches, tell the user...
       else {
         var speechOutput = this.t("CLUB_NOT_FOUND_MESSAGE", clubName)
         this.attributes['speechOutput'] = speechOutput


### PR DESCRIPTION
we only want to get new stories from the scraper if the old stories are more than a day old. 

This pr adds a Dynamo DB table that holds a cache, and there's logic in the new `Dispatcher` module that decides whether a given request should update the cache with new stories or use the ones we already found.